### PR TITLE
fix(relationCard): 修改关系卡片的bug

### DIFF
--- a/src/components/RelationCard/index.vue
+++ b/src/components/RelationCard/index.vue
@@ -220,7 +220,7 @@ export default {
       )
     },
     addObjects() {
-      const objects = this.$refs.select2.getOptionsByValues(this.select2.value)
+      const objects = this.$refs.select2.$refs.select.selected.map(item => ({ label: item.label, value: item.value }))
       if (objects.length === 0) {
         return
       }


### PR DESCRIPTION
原来数据是从 options 中过滤获取的, 当搜索结束后就无法在获取到，所以改成从select中获取选中的