### PR TITLE
fix:  优化资产树 mini-button 添加 `cursor:pointer`

### DIFF
--- a/src/components/TreeTable/index.vue
+++ b/src/components/TreeTable/index.vue
@@ -98,6 +98,7 @@ export default {
     color: #FFFFFF;
     border-radius: 3px;
     line-height: 1.428;
+    cursor:pointer;
   }
   .el-tree{
     background-color: inherit !important;


### PR DESCRIPTION
fix:  优化资产树 mini-button 添加 `cursor:pointer`