### PR TITLE
fix(AssetUpdate): 创建资产网域选项可清空

### DIFF
--- a/src/views/assets/Asset/AssetCreateUpdate.vue
+++ b/src/views/assets/Asset/AssetCreateUpdate.vue
@@ -50,6 +50,7 @@ export default {
         domain: {
           el: {
             multiple: false,
+            clearable: true,
             ajax: {
               url: '/api/v1/assets/domains/'
             }


### PR DESCRIPTION
Closes https://github.com/jumpserver/lina/issues/141