### PR TITLE
perf: 屏蔽--secure参数，目前redis-cli版本为6.0，暂时用不到

### DIFF
--- a/src/views/applications/DatabaseApp/const.js
+++ b/src/views/applications/DatabaseApp/const.js
@@ -2,14 +2,14 @@ import { ORACLE, MONGODB, REDIS } from '../const'
 
 export function getDatabaseTypeFieldsMap(type) {
   const baseParams = ['host', 'port', 'database']
-  const tlsParams = ['use_ssl', 'allow_invalid_cert', 'ca_cert']
+  const tlsParams = ['use_ssl', 'ca_cert']
   switch (type) {
     case ORACLE:
       return baseParams.concat(['version'])
     case REDIS:
       return baseParams.concat(tlsParams.concat(['client_cert', 'cert_key']))
     case MONGODB:
-      return baseParams.concat(tlsParams.concat(['cert_key']))
+      return baseParams.concat(tlsParams.concat(['cert_key', 'allow_invalid_cert']))
     default:
       return baseParams
   }


### PR DESCRIPTION
perf: 屏蔽--secure参数，目前redis-cli版本为6.0，暂时用不到