### PR TITLE
fix: reset stale asset protocols on platform change

### DIFF
--- a/src/components/Form/FormFields/ProtocolSelector/index.vue
+++ b/src/components/Form/FormFields/ProtocolSelector/index.vue
@@ -280,8 +280,11 @@ export default {
     setDefaultItems(choices) {
       let items = []
       const requiredItems = choices.filter(item => (item.required || item.primary))
+      const choiceNames = new Set(choices.map(item => item.name))
+      const hasUnsupportedValue = this.settingReadonly && Array.isArray(this.value) &&
+        this.value.some(item => !choiceNames.has(item.name))
 
-      if (this.value instanceof Array && this.value.length > 0) {
+      if (Array.isArray(this.value) && this.value.length > 0 && !hasUnsupportedValue) {
         const protocols = []
         this.value.forEach(item => {
           // 有默认值的情况下，设置为只读或者有id、有setting是平台
@@ -309,7 +312,10 @@ export default {
     },
     getAssetDefaultItems(item, choices) {
       const protocols = []
-      const protocol = choices.find(i => i.name === item.name) || {}
+      const protocol = choices.find(i => i.name === item.name)
+      if (!protocol) {
+        return protocols
+      }
       protocols.push({ ...protocol, ...item })
       return protocols
     },

--- a/tests/unit/components/ProtocolSelector.spec.js
+++ b/tests/unit/components/ProtocolSelector.spec.js
@@ -1,0 +1,104 @@
+import { shallowMount } from '@vue/test-utils'
+
+jest.mock('@/components/Form/FormFields/ProtocolSelector/ProtocolSettingDialog.vue', () => ({
+  name: 'ProtocolSettingDialog',
+  render(h) {
+    return h('div')
+  }
+}))
+
+import ProtocolSelector from '@/components/Form/FormFields/ProtocolSelector/index.vue'
+
+const mountSelector = (propsData) => shallowMount(ProtocolSelector, {
+  propsData,
+  stubs: ['el-button', 'el-input', 'el-option', 'el-select'],
+  mocks: {
+    $t: key => key,
+    $log: {
+      debug: jest.fn()
+    }
+  }
+})
+
+describe('ProtocolSelector.vue', () => {
+  it('resets stale asset protocols when platform choices change', () => {
+    const wrapper = mountSelector({
+      settingReadonly: true,
+      value: [
+        { name: 'rdp', port: 3389 },
+        { name: 'ssh', port: 22 }
+      ],
+      choices: [
+        { name: 'rdp', port: 3389, primary: true },
+        { name: 'ssh', port: 22 }
+      ]
+    })
+
+    wrapper.vm.setDefaultItems([
+      { name: 'ssh', port: 22, primary: true },
+      { name: 'sftp', port: 22, default: true }
+    ])
+
+    expect(wrapper.vm.items.map(item => item.name)).toEqual(['ssh', 'sftp'])
+  })
+
+  it('initializes default protocols when asset protocols are empty', () => {
+    const wrapper = mountSelector({
+      settingReadonly: true,
+      value: [],
+      choices: []
+    })
+
+    wrapper.vm.setDefaultItems([
+      { name: 'ssh', port: 22, primary: true },
+      { name: 'sftp', port: 22, default: true }
+    ])
+
+    expect(wrapper.vm.items.map(item => item.name)).toEqual(['ssh', 'sftp'])
+  })
+
+  it('keeps supported asset protocols when platform choices remain compatible', () => {
+    const wrapper = mountSelector({
+      settingReadonly: true,
+      value: [
+        { name: 'ssh', port: 2222 }
+      ],
+      choices: [
+        { name: 'ssh', port: 22, primary: true },
+        { name: 'sftp', port: 22, default: true }
+      ]
+    })
+
+    wrapper.vm.setDefaultItems([
+      { name: 'ssh', port: 22, primary: true },
+      { name: 'sftp', port: 22, default: true }
+    ])
+
+    expect(wrapper.vm.items).toEqual([
+      { name: 'ssh', port: 2222, primary: true }
+    ])
+  })
+
+  it('adds required protocols missing from compatible asset protocols', () => {
+    const wrapper = mountSelector({
+      settingReadonly: true,
+      value: [
+        { name: 'ssh', port: 2222 }
+      ],
+      choices: [
+        { name: 'ssh', port: 22, primary: true },
+        { name: 'sftp', port: 22, required: true }
+      ]
+    })
+
+    wrapper.vm.setDefaultItems([
+      { name: 'ssh', port: 22, primary: true },
+      { name: 'sftp', port: 22, required: true }
+    ])
+
+    expect(wrapper.vm.items).toEqual([
+      { name: 'ssh', port: 2222, primary: true },
+      { name: 'sftp', port: 22, required: true }
+    ])
+  })
+})


### PR DESCRIPTION
## Problem

Changing the selected asset platform refreshes `protocols.el.choices`, but the form intentionally does not clear the current `protocols` value in `updatePlatformProtocols()`. That preserves gateway-switch behavior, but it also means `ProtocolSelector` can keep protocol values from the previously selected platform.

One reproducible case is a Windows asset form that starts from a platform exposing `rdp` and then switches to a custom Windows OpenSSH platform exposing only `ssh` and `sftp`. The platform choices are updated correctly, but the selector can still carry the old `rdp` item and miss the new platform default such as `sftp`.

## Root Cause

`setDefaultItems()` preferred existing asset protocol values whenever `this.value` was non-empty. `getAssetDefaultItems()` also returned the old item even when the new platform choices did not contain that protocol name. As a result, unsupported protocols could survive a platform change.

## Fix

In asset protocol mode (`settingReadonly`), detect whether the current value contains protocol names that are absent from the new choices. If unsupported values are found, rebuild the selector items from the current platform defaults (`required`, `primary`, or `default`) instead of carrying stale values forward.

If the existing values are still compatible with the new platform choices, the selector keeps them, including custom ports, and still adds missing required/primary protocols as before. This keeps the behavior needed by the existing gateway-switch comment while fixing platform changes that actually replace the protocol set.

This also drops absent protocols in `getAssetDefaultItems()` and uses `Array.isArray()` / `Set.has()` to address the SonarCloud warnings on the changed lines.

## Tests

Added `ProtocolSelector` unit coverage for:

- stale `rdp + ssh` values resetting to `ssh + sftp` after the platform choices change
- empty asset protocol values initializing from platform defaults
- compatible protocol values preserving custom ports
- missing required protocols being added to compatible values

Validated locally with:

- `npm_config_registry=https://registry.npmmirror.com npx -y yarn@1.22.22 install --frozen-lockfile --registry https://registry.npmmirror.com --network-timeout 600000`
- `./node_modules/.bin/eslint src/components/Form/FormFields/ProtocolSelector/index.vue tests/unit/components/ProtocolSelector.spec.js`
- `git diff --check`
- Docker `node:20-bullseye` targeted test: `yarn test:unit tests/unit/components/ProtocolSelector.spec.js` passed with 4 tests

Note: the full local `yarn test:unit` suite still has unrelated existing failures in this checkout: old Jest/Babel setup requires the Babel 7 bridge package, two utils specs import files that are not present at `src/utils/index.js` and `src/utils/validate.js`, and `Breadcrumb.spec.js` imports Element UI which pulls untransformed `lodash-es` ESM. The new `ProtocolSelector` spec passes in the isolated Docker test environment.
