### PR TITLE
fix: preselect asset tree node when creating asset

### DIFF
--- a/src/components/Apps/AssetTreeTable/index.vue
+++ b/src/components/Apps/AssetTreeTable/index.vue
@@ -202,11 +202,11 @@ export default {
         const query = this.setTreeUrlQuery()
         url = query ? `${url}&${query}` : url
         this.$set(this.tableConfig, 'url', url)
-      })
 
-      if (this.treeSetting.selectSyncToRoute !== false) {
-        setRouterQuery(this, url)
-      }
+        if (this.treeSetting.selectSyncToRoute !== false) {
+          setRouterQuery(this, url)
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
修复在资产列表中点击资产树节点后再点“创建”时节点不会自动选中的问题
原因为 AssetTreeTable.getAssetsUrl() 里 setRouterQuery() 同步执行，早于被 setTimeout 延迟的参数写入，导致 node_id 没能写进路由 query，创建资产界面因此读不到节点；改动是把 setRouterQuery() 挪进最后那个 setTimeout 内，等 url 拼好后再同步路由，使 node_id 正确传入并自动选中节点。