### PR TITLE
fix: cloud sync IP type default display and result panel font

### DIFF
--- a/src/components/Table/TableFormatters/AccountConnectFormatter.vue
+++ b/src/components/Table/TableFormatters/AccountConnectFormatter.vue
@@ -146,13 +146,12 @@ export default {
   cursor: pointer;
 
   .el-button {
-    // 只含一个图标,做成紧凑的方形按钮(EP small 的默认 padding 会把它撑得又扁又宽)
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 28px;
-    min-width: 28px;
-    height: 28px;
+    width: 24px;
+    min-width: 24px;
+    height: 24px;
     padding: 0;
     line-height: 1;
     box-shadow: none !important;
@@ -162,7 +161,7 @@ export default {
     i {
       display: block;
       line-height: 1;
-      transform: translateY(1px);
+      transform: translateX(1px) translateY(1px);
     }
 
     &:hover,

--- a/src/views/assets/Cloud/Account/AccountDetail/AccountDetail.vue
+++ b/src/views/assets/Cloud/Account/AccountDetail/AccountDetail.vue
@@ -68,7 +68,8 @@ export default {
           title: this.$t('IPType'),
           type: 'updateSelect',
           attrs: {
-            model: this.object.task.sync_ip_type,
+            value: this.object.task.sync_ip_type === 1 ? 1 : 0,
+            model: this.object.task.sync_ip_type === 1 ? 1 : 0,
             type: 'primary',
             multiple: false,
             clearable: false,

--- a/src/views/assets/Cloud/Account/components/ResultPanel.vue
+++ b/src/views/assets/Cloud/Account/components/ResultPanel.vue
@@ -64,6 +64,14 @@ export default {
 .result-panel {
   padding: 10px;
 
+  :deep(.el-table) {
+    font-size: 13px;
+  }
+
+  :deep(.el-link) {
+    font-size: 13px;
+  }
+
   &__actions {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
- Bind value on the IP type select in the cloud account detail quick-update panel so it defaults to Private IP (previously only model was passed and never reached the component's value prop, so it always showed the placeholder)
- Unify step4 result panel font size to 13px in the cloud sync create wizard
- Adjust connect button size to 24px