### PR TITLE
fix: resolve Vue 3 migration issues across settings and shared components

### DIFF
--- a/src/components/Apps/GatewayTestDialog/index.vue
+++ b/src/components/Apps/GatewayTestDialog/index.vue
@@ -10,26 +10,25 @@
     width="40%"
     @update:visible="$emit('update:visible', $event)"
   >
-    <el-row :gutter="20">
-      <el-col :md="4" :sm="24">
-        <div style="line-height: 34px">{{ $t('SSHPort') }}</div>
-      </el-col>
-      <el-col :md="14" :sm="24">
-        <el-input v-model="iPort" />
-        <span class="help-tips help-block">{{ $t('TestGatewayHelpMessage') }}</span>
-      </el-col>
-      <el-col :md="4" :sm="24">
-        <el-button
-          :loading="loading"
-          size="small"
-          style="line-height: 20px"
-          type="primary"
-          @click="dialogConfirm"
-        >
-          {{ $t('Confirm') }}
-        </el-button>
-      </el-col>
-    </el-row>
+    <div class="gateway-test">
+      <div class="gateway-test__row">
+        <span class="gateway-test__label">{{ $t('SSHPort') }}</span>
+        <div class="gateway-test__field">
+          <div class="gateway-test__control">
+            <el-input v-model="iPort" :placeholder="$t('SSHPort')" class="gateway-test__input" />
+            <el-button
+              :loading="loading"
+              class="gateway-test__btn"
+              type="primary"
+              @click="dialogConfirm"
+            >
+              {{ $t('Confirm') }}
+            </el-button>
+          </div>
+          <div class="gateway-test__tip">{{ $t('TestGatewayHelpMessage') }}</div>
+        </div>
+      </div>
+    </div>
   </Dialog>
 </template>
 
@@ -62,25 +61,28 @@ export default {
   },
   emits: ['update:visible', 'update:port'],
   data() {
-    return {}
+    return {
+      // 用本地 state 承接端口:父组件仅单向传入 :port(无 v-model:port),
+      // 若沿用受控 computed 会因父组件不回传 update:port 而导致无法输入。
+      iPort: this.port
+    }
   },
-  computed: {
-    iPort: {
-      get() {
-        return this.port
+  watch: {
+    port: {
+      handler(val) {
+        this.iPort = val
       },
-      set(val) {
-        this.$emit('update:port', val)
-      }
+      immediate: true
     }
   },
   methods: {
     dialogConfirm() {
-      if (isNaN(this.port)) {
+      if (this.iPort === '' || isNaN(this.iPort)) {
         return this.$message.error(this.$tc('TestPortErrorMsg'))
       }
+      this.$emit('update:port', this.iPort)
       this.$axios
-        .post(`/api/v1/assets/gateways/${this.cell}/test-connective/`, { port: this.port })
+        .post(`/api/v1/assets/gateways/${this.cell}/test-connective/`, { port: Number(this.iPort) })
         .then((res) => {
           openTaskPage(res['task'])
         })
@@ -91,3 +93,57 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.gateway-test {
+  &__row {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  &__label {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    font-size: 13px;
+    line-height: 30px; // 与首行 30px 输入框垂直对齐
+    color: var(--color-text-primary);
+  }
+
+  // 标签右侧的纵向列:输入行 + 提示,使提示左侧与输入框左侧对齐
+  &__field {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__control {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  &__input {
+    flex: 1 1 auto;
+    min-width: 0;
+
+    :deep(.el-input__wrapper) {
+      min-height: 30px;
+      height: 30px;
+    }
+  }
+
+  &__btn {
+    flex: 0 0 auto;
+    height: 30px;
+  }
+
+  &__tip {
+    margin-top: 8px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+  }
+}
+</style>

--- a/src/components/Form/FormFields/TagInput.vue
+++ b/src/components/Form/FormFields/TagInput.vue
@@ -243,7 +243,8 @@ export default {
   width: 100%;
   min-height: 30px;
   height: auto;
-  padding: 0 8px 0 4px;
+  // 边框由当前容器承担，输入文字的水平留白统一交由内部 wrapper（11px）处理。
+  padding: 0;
   box-sizing: border-box;
   border: 1px solid #dcdee2;
   border-radius: 1px;
@@ -320,7 +321,6 @@ export default {
     -webkit-appearance: none !important;
     box-shadow: none !important;
     background: transparent !important;
-    padding-left: 8px;
     height: 28px;
     line-height: 28px;
   }
@@ -333,6 +333,8 @@ export default {
 
   & :deep(.el-input__wrapper) {
     width: 100%;
+    // 与标准 el-input 一样由 wrapper 承担留白；inner 的 padding 会被公共规则清零。
+    padding: 0 11px !important;
     border: none !important;
     box-shadow: none !important;
     background: transparent !important;

--- a/src/components/Libs/Krry/paging/models/box.vue
+++ b/src/components/Libs/Krry/paging/models/box.vue
@@ -24,7 +24,7 @@
           type="text"
           @change="handleKeyword"
         />
-        <span class="el-input__prefix" style="left: 0">
+        <span class="el-input__prefix">
           <el-icon class="el-input__icon"><Search /></el-icon>
         </span>
         <span v-if="searchWord && showClearBtn" class="clear-input">
@@ -276,13 +276,34 @@ export default {
 <style lang="scss" scoped>
 .district-panel {
   width: 298px;
+  display: inline-block;
+  box-sizing: border-box;
+  vertical-align: middle;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid var(--el-border-color, #dcdfe6);
+  border-radius: 4px;
 
   .el-transfer-panel__header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    height: 40px;
+    margin: 0;
+    padding: 0 15px;
+    box-sizing: border-box;
+    background: var(--el-fill-color-light, #f5f7fa);
+    border-bottom: 1px solid var(--el-border-color-lighter, #ebeef5);
+
     .el-checkbox {
-      display: inline-block;
+      display: inline-flex;
+      align-items: center;
+      height: auto;
+      margin-right: 0;
 
       :deep(.el-checkbox__label) {
         font-size: 14px;
+        line-height: 1;
       }
     }
   }
@@ -291,16 +312,57 @@ export default {
     height: 335px;
 
     .el-transfer-panel__filter {
-      margin: 6px 14px;
-      line-height: 0;
+      // 该 div 同时带了 EP 的 .el-input 类(inline-flex + width:100%),会把 input 与图标当作
+      // flex 项并排错位,且 width:100% 叠加左右 margin 会溢出面板。强制 block + width:auto:
+      // 块级自动填满(减去 margin),input 独占整行,图标绝对定位覆盖在左侧。
+      display: block;
+      width: auto;
+      // 该 div 还带 EP 的 .el-input 类,会被赋予固定 height:var(--el-input-height,32px);
+      // 这里改回 auto,让容器高度由内部 30px 的 input 决定,避免 32/30 错位
+      height: auto;
+      box-sizing: border-box;
+      position: relative;
+      // margin: 10px 15px;
+      line-height: normal;
 
       .el-input__inner {
+        display: block;
+        width: 100%;
         height: 30px;
+        line-height: 30px;
+        box-sizing: border-box;
+        padding-left: 25px;
+        border: 1px solid var(--el-border-color, #dcdfe6);
+        border-radius: 4px;
+        font-size: 13px;
+
+        &:focus {
+          outline: none;
+          border-color: var(--el-color-primary);
+        }
+      }
+
+      .el-input__prefix {
+        position: absolute;
+        height: 30px;
+        left: 15px;
+        top: 15px;
+        width: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--el-text-color-placeholder, #a8abb2);
+        pointer-events: none;
+
+        .el-input__icon {
+          height: 30px;
+          font-size: 14px;
+          margin: 0;
+        }
       }
 
       .showClear {
         padding-right: 30px;
-        border-radius: 0;
       }
 
       .clear-input {
@@ -356,7 +418,8 @@ export default {
   .check-number {
     position: absolute;
     right: 15px;
-    top: 0;
+    top: 50%;
+    transform: translateY(-50%);
     color: #909399;
     font-size: 12px;
     font-weight: 400;
@@ -375,16 +438,21 @@ export default {
   .vip-footer {
     display: flex;
     position: relative;
+    width: 100%;
+    box-sizing: border-box;
     margin: 0;
     text-align: center;
     border-top: 1px solid #ebeef5;
 
     .v-page {
       width: 50%;
+      height: 30px;
+      padding: 0;
       border: none;
       margin: 0;
       border-radius: 0;
-      padding: 10px 15px;
+      font-size: 13px;
+      line-height: 1;
 
       &:first-child {
         border-right: 1px solid #ebeef5;

--- a/src/components/Widgets/Announcement/index.vue
+++ b/src/components/Widgets/Announcement/index.vue
@@ -37,7 +37,7 @@
       :center="false"
       :title="title"
       class="announcement"
-      type="success"
+      type="info"
       @close="onAlertClose"
     >
       <MarkDown :value="announcement.content" class="markdown" />

--- a/src/router/settings/index.js
+++ b/src/router/settings/index.js
@@ -34,7 +34,6 @@ export default {
   meta: {
     title: i18n.t('Settings'),
     icon: 'system-setting',
-    activeMenu: '/settings',
     view: 'settings',
     type: 'view',
     showNavSwitcher: false,

--- a/src/styles/element-form-controls.scss
+++ b/src/styles/element-form-controls.scss
@@ -130,6 +130,13 @@
     padding: 1px 11px;
   }
 
+  // 普通表单项的直接输入框必须由 wrapper 提供水平留白。inner 的 padding 会在下方
+  // 统一清零；若页面或组件样式把 wrapper 重置为 0，placeholder 会紧贴边框。
+  // 仅匹配直接子节点，避免影响 TagInput、输入组等需要自行管理间距的复合控件。
+  > .el-input:not(.el-input-group) > .el-input__wrapper {
+    padding: 1px 11px !important;
+  }
+
   .el-select__wrapper,
   .el-cascader .el-input__wrapper,
   .el-date-editor .el-input__wrapper {

--- a/src/utils/common/index.js
+++ b/src/utils/common/index.js
@@ -1,7 +1,10 @@
 import i18n from '@/i18n/i18n'
 import { message } from '@/utils/vue/message'
 import { getBasePath } from '@/utils/storage'
+import { toSentenceCase } from './string'
 import _ from 'lodash'
+
+export { toSentenceCase }
 
 export function getApiPath(that, objectId) {
   let pagePath = that.$route.path
@@ -376,34 +379,6 @@ export function toTitleCase(string) {
       return item[0].toUpperCase() + item.slice(1)
     })
     .join(' ')
-}
-
-export function toSentenceCase(string) {
-  if (!string) return string
-  if (string.indexOf('/') > 0) return string
-  const s = string
-    .trim()
-    .split(' ')
-    .map((item, index) => {
-      if (item.length === 0) return ''
-      if (item.length === 1) return item.toLowerCase()
-
-      // 如果首字母大写，且第二个字母也大写，不处理
-      if (item[0] === item[0].toUpperCase() && item[1] === item[1].toUpperCase()) {
-        return item
-      }
-
-      if (index === 0) {
-        return item[0].toUpperCase() + item.slice(1)
-      }
-      // 仅处理首字母大写，别的是小写的情况
-      if (item[0] !== item[0].toLowerCase() && item.slice(1) === item.slice(1).toLowerCase()) {
-        return item[0].toLowerCase() + item.slice(1)
-      }
-      return item
-    })
-    .join(' ')
-  return s[0].toUpperCase() + s.slice(1)
 }
 
 export function toLowerCaseExcludeAbbr(s) {

--- a/src/utils/common/string.js
+++ b/src/utils/common/string.js
@@ -1,0 +1,25 @@
+export function toSentenceCase(string) {
+  if (!string) return string
+  if (string.indexOf('/') > 0) return string
+  const sentence = string
+    .trim()
+    .split(' ')
+    .map((item, index) => {
+      if (item.length === 0) return ''
+      if (item.length === 1) return item.toLowerCase()
+
+      if (item[0] === item[0].toUpperCase() && item[1] === item[1].toUpperCase()) {
+        return item
+      }
+
+      if (index === 0) {
+        return item[0].toUpperCase() + item.slice(1)
+      }
+      if (item[0] !== item[0].toLowerCase() && item.slice(1) === item.slice(1).toLowerCase()) {
+        return item[0].toLowerCase() + item.slice(1)
+      }
+      return item
+    })
+    .join(' ')
+  return sentence[0].toUpperCase() + sentence.slice(1)
+}

--- a/src/utils/vue/message.js
+++ b/src/utils/vue/message.js
@@ -1,5 +1,5 @@
 import { ElMessage as elMessage } from 'element-plus'
-import { toSentenceCase } from '@/utils/common/index'
+import { toSentenceCase } from '@/utils/common/string'
 
 let messageDom = null
 const DEFAULT_Z_INDEX = 20000

--- a/src/views/labels/BindDialog.vue
+++ b/src/views/labels/BindDialog.vue
@@ -10,10 +10,8 @@
     @confirm="handleConfirm"
   >
     <div style="padding: 0 20px 20px">
-      <el-row>
-        <div class="label-zone">
-          <label class="type-label" for="">{{ $t('ResourceType') }}: </label>
-        </div>
+      <el-row class="type-row jms-form-controls">
+        <label class="type-label" for="">{{ $t('ResourceType') }}: </label>
         <el-select v-model="select2.value" class="select2" @change="handleChangeType">
           <el-option-group v-for="group in select2.options" :key="group.label" :label="group.label">
             <el-option
@@ -156,17 +154,23 @@ export default {
   margin: 20px;
 }
 
-.type-label {
-  width: 200px;
-  display: block;
-}
-
-.select2 {
-  width: 300px;
-}
-
 .el-row {
   margin: 20px 0;
+}
+
+// 资源类型行:label 在左,select 占满剩余宽度(右边缘与下方穿梭框对齐)
+.type-row {
+  display: flex;
+  align-items: center;
+
+  .type-label {
+    margin-right: 12px;
+    white-space: nowrap;
+  }
+
+  .select2 {
+    flex: 1;
+  }
 }
 
 .label-zone {

--- a/src/views/settings/Feature/Chat.vue
+++ b/src/views/settings/Feature/Chat.vue
@@ -10,7 +10,6 @@
 import { GenericCreateUpdateForm } from '@/layout/components'
 import IBox from '@/components/Common/IBox/index.vue'
 import { mapGetters } from 'vuex'
-import ChatProvidersField from './components/ChatProvidersField.vue'
 
 export default {
   components: {
@@ -18,48 +17,125 @@ export default {
     GenericCreateUpdateForm
   },
   data() {
-    const hasProviders = (formValue) => {
-      const providers = formValue?.CHAT_AI_PROVIDERS?.providers || []
-      return Array.isArray(providers) && providers.length > 0
-    }
+    const vm = this
     return {
       url: '/api/v1/settings/setting/?category=chat',
       hasReset: false,
-      moreButtons: [],
+      moreButtons: [
+        {
+          title: this.$t('Test'),
+          loading: false,
+          callback: function (value, form, btn) {
+            btn.loading = true
+            vm.$axios
+              .post('/api/v1/settings/chatai/testing/', value)
+              .then((res) => {
+                vm.$message.success(res['msg'])
+              })
+              .catch(() => {
+                vm.$log.error('err occur')
+              })
+              .finally(() => {
+                btn.loading = false
+              })
+          }
+        }
+      ],
       encryptedFields: ['VAULT_HCP_TOKEN'],
-      fields: ['CHAT_AI_ENABLED', 'CHAT_AI_METHOD', 'CHAT_AI_PROVIDERS', 'CHAT_AI_EMBED_URL'],
+      fields: [
+        'CHAT_AI_ENABLED',
+        'CHAT_AI_METHOD',
+        'CHAT_AI_EMBED_URL',
+        'CHAT_AI_TYPE',
+        'DEEPSEEK_BASE_URL',
+        'DEEPSEEK_API_KEY',
+        'DEEPSEEK_PROXY',
+        'DEEPSEEK_MODEL',
+        'GPT_BASE_URL',
+        'GPT_API_KEY',
+        'GPT_PROXY',
+        'GPT_MODEL',
+        'CUSTOM_GPT_MODEL',
+        'CUSTOM_DEEPSEEK_MODEL'
+      ],
       fieldsMeta: {
         CHAT_AI_TYPE: {
           hidden: (formValue) => {
-            return formValue.CHAT_AI_METHOD !== 'api' || hasProviders(formValue)
+            return formValue.CHAT_AI_METHOD !== 'api'
           }
         },
-        CHAT_AI_PROVIDERS: {
-          component: ChatProvidersField,
-          hidden: (formValue) => formValue.CHAT_AI_METHOD !== 'api'
+        GPT_BASE_URL: {
+          el: {
+            autocomplete: 'new-password'
+          },
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'gpt'
+          }
+        },
+        GPT_API_KEY: {
+          el: {
+            autocomplete: 'new-password'
+          },
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'gpt'
+          }
+        },
+        GPT_PROXY: {
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'gpt'
+          }
+        },
+        GPT_MODEL: {
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'gpt'
+          }
+        },
+        DEEPSEEK_BASE_URL: {
+          el: {
+            autocomplete: 'new-password'
+          },
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'deep-seek'
+          }
+        },
+        DEEPSEEK_API_KEY: {
+          el: {
+            autocomplete: 'new-password'
+          },
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'deep-seek'
+          }
+        },
+        DEEPSEEK_PROXY: {
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'deep-seek'
+          }
+        },
+        DEEPSEEK_MODEL: {
+          hidden: (formValue) => {
+            return formValue.CHAT_AI_METHOD !== 'api' || formValue.CHAT_AI_TYPE !== 'deep-seek'
+          }
         },
         CHAT_AI_EMBED_URL: {
           hidden: (formValue) => formValue.CHAT_AI_METHOD !== 'embed'
-        }
-      },
-      afterGetFormValue(formValue) {
-        const providers = Array.isArray(formValue.CHAT_AI_PROVIDERS)
-          ? formValue.CHAT_AI_PROVIDERS
-          : []
-        return {
-          ...formValue,
-          CHAT_AI_PROVIDERS: {
-            providers: providers
+        },
+        CUSTOM_GPT_MODEL: {
+          hidden: (formValue) => {
+            return (
+              formValue.CHAT_AI_METHOD !== 'api' ||
+              formValue.CHAT_AI_TYPE !== 'gpt' ||
+              formValue.GPT_MODEL !== 'custom'
+            )
           }
-        }
-      },
-      cleanFormValue(values) {
-        const config = values.CHAT_AI_PROVIDERS || {}
-        const providers = Array.isArray(config.providers) ? config.providers : []
-        return {
-          ...values,
-          CHAT_AI_PROVIDERS: providers,
-          CHAT_AI_TYPE: values.CHAT_AI_TYPE || providers[0]?.type || values.CHAT_AI_TYPE
+        },
+        CUSTOM_DEEPSEEK_MODEL: {
+          hidden: (formValue) => {
+            return (
+              formValue.CHAT_AI_METHOD !== 'api' ||
+              formValue.CHAT_AI_TYPE !== 'deep-seek' ||
+              formValue.DEEPSEEK_MODEL !== 'custom'
+            )
+          }
         }
       },
       submitMethod() {

--- a/src/views/settings/Msg/Email/markDownEditor.vue
+++ b/src/views/settings/Msg/Email/markDownEditor.vue
@@ -75,6 +75,9 @@ export default {
 </script>
 <style lang="scss" scoped>
 .markdown-editor {
+  // 表单项内容区是 flex 容器,不设宽度会按内容收缩成窄条,这里撑满可用宽度
+  width: 100%;
+  box-sizing: border-box;
   position: relative;
   padding: 10px;
   border: 1px solid #dcdfe6;

--- a/src/views/settings/Msg/MsgTemplate/index.vue
+++ b/src/views/settings/Msg/MsgTemplate/index.vue
@@ -74,6 +74,9 @@ export default {
           }
         },
         template_content: {
+          // 保留表单 label 列的占位，使编辑器左边界与上方名称控件对齐。
+          // 不能用空格：字段生成器会 trim；零宽空格不会显示，也不会被 trim。
+          label: '\u200B',
           component: MarkDownEditor,
           on: {
             htmlChange: ([html]) => {

--- a/src/views/settings/Storage/index.vue
+++ b/src/views/settings/Storage/index.vue
@@ -17,12 +17,6 @@ export default {
     ReplayStorage,
     CommandStorage
   },
-  beforeRouteUpdate(to, from) {
-    if (to.name === from.name && to.path === from.path && to.query?.tab) {
-      this.$store.commit('common/reload')
-    }
-    return true
-  },
   data() {
     return {
       loading: true,

--- a/src/views/settings/Terminal/Monitor/component/MonitorCard.vue
+++ b/src/views/settings/Terminal/Monitor/component/MonitorCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div ref="card">
     <el-card class="box-card" shadow="never">
       <el-row :gutter="10">
         <el-col :md="19" :sm="24" style="padding-right: 15px">
@@ -44,7 +44,7 @@
                 </span>
               </span>
             </div>
-            <div :class="componentMetric.type + '-progress'" class="progress">
+            <div ref="progress" :class="componentMetric.type + '-progress'" class="progress">
               <div style="position: absolute; height: 100%; padding: 2px 0">
                 <span v-for="(bar, index) in barArray" :key="index" class="box-bar" />
               </div>
@@ -156,14 +156,13 @@ export default {
   mounted() {
     this.$nextTick(() => {
       this.resizeObserver = new ResizeObserver(this.setBarColor)
-      this.resizeObserver.observe(document.querySelector('.box-card'))
+      if (this.$refs.card instanceof Element) {
+        this.resizeObserver.observe(this.$refs.card)
+      }
     })
   },
   beforeUnmount() {
-    const el = document.querySelector('.box-card')
-    if (el) {
-      this.resizeObserver.unobserve(el)
-    }
+    this.resizeObserver?.disconnect()
     this.resizeObserver = null
   },
   methods: {
@@ -171,8 +170,7 @@ export default {
       return legacyIconComponents[name] || null
     },
     setElementsColor(numArray) {
-      const className = `.${this.componentMetric.type}-progress .box-bar`
-      const elements = document.querySelectorAll(className)
+      const elements = this.$el.querySelectorAll('.box-bar')
       numArray.reduce((prev, cur) => {
         for (let i = prev; i < cur.num + prev && i < elements.length; i++) {
           elements[i].style.backgroundColor = cur.color
@@ -181,7 +179,7 @@ export default {
       }, 0)
     },
     setBarColor() {
-      const el = document.querySelector(`.${this.componentMetric.type}-progress`)
+      const el = this.$refs.progress
       if (!el) return
 
       const numArray = []

--- a/src/views/settings/Terminal/index.vue
+++ b/src/views/settings/Terminal/index.vue
@@ -25,12 +25,6 @@ export default {
     EndpointRuleList,
     ComponentLog
   },
-  beforeRouteUpdate(to, from) {
-    if (to.name === from.name && to.path === from.path && to.query?.tab) {
-      this.$store.commit('common/reload')
-    }
-    return true
-  },
   data() {
     return {
       loading: true,

--- a/src/views/settings/Tool/Base.vue
+++ b/src/views/settings/Tool/Base.vue
@@ -1,6 +1,6 @@
 <template>
   <IBox>
-    <el-form ref="testForm" :model="testData" :rules="rules" label-width="15%">
+    <el-form ref="testForm" class="tool-form" :model="testData" :rules="rules" label-width="15%">
       <div v-for="field in safeFields" :key="field.name">
         <div v-if="Array.isArray(field)">
           <el-form-item label-width="8%">
@@ -42,9 +42,14 @@
         </div>
       </div>
       <el-form-item :label="$tc('Output')">
-        <Term ref="xterm" :xterm-config="xtermConfig" style="border: solid 1px #dddddd" />
+        <Term
+          ref="xterm"
+          class="tool-output"
+          :xterm-config="xtermConfig"
+          style="border: solid 1px #dddddd"
+        />
       </el-form-item>
-      <el-form-item>
+      <el-form-item class="tool-actions">
         <el-button v-if="!isTesting" size="small" type="primary" @click="submitTest">
           <i class="fa fa-play" style="margin-right: 4px" />{{ $t('Test') }}
         </el-button>
@@ -171,18 +176,37 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-:deep(.el-form-item) {
-  margin-bottom: 20px;
+:deep(.tool-form) {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
 
-  .el-form-item__label {
-    height: 30px;
-    line-height: 30px;
-    display: inline-flex;
-    align-items: center;
-  }
+:deep(.tool-form > .el-form-item),
+:deep(.tool-form > div > .el-form-item) {
+  // 由容器 gap 统一管理字段间距，避免被全局 el-form 规则覆盖或叠加。
+  margin-bottom: 0 !important;
+}
 
-  .el-form-item {
-    margin-bottom: 0;
-  }
+:deep(.tool-form .el-form-item__label) {
+  height: 30px;
+  line-height: 30px;
+  display: inline-flex;
+  align-items: center;
+}
+
+:deep(.tool-form .el-form-item .el-form-item) {
+  margin-bottom: 0;
+}
+
+:deep(.tool-form > .tool-actions .el-form-item__content) {
+  // 小尺寸按钮默认按 30px 行高基线居中，会让可见边框比其它控件多出约 5px 间隙。
+  align-items: flex-start;
+  line-height: normal;
+}
+
+:deep(.tool-output) {
+  width: 100%;
+  min-width: 0;
 }
 </style>

--- a/src/views/tickets/TicketFlow/FlowRuleField.vue
+++ b/src/views/tickets/TicketFlow/FlowRuleField.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="flow-rule-field">
     <div v-for="(item, i) of approveData" :key="i">
       <el-card class="box-card">
         <template #header>
@@ -27,6 +27,11 @@ export default {
   components: {
     JSONManyToManySelect
   },
+  // 根节点是 <div>。若不声明 emits / 关闭 inheritAttrs,DataForm 绑定的 onInput 等会落到根 div,
+  // 内部单选按钮(值 all/ids/attrs)的原生 input 事件冒泡上来即触发表单更新,把字符串(如 "ids")
+  // 当成整个 rules 的值(再经 cleanFormValue 的 slice 变成 "i"),污染 PUT 参数。
+  inheritAttrs: false,
+  emits: ['input'],
   props: {
     value: {
       type: [String, Array],
@@ -104,8 +109,14 @@ export default {
   padding: 10px 0;
 }
 
+// 根容器需占满表单项内容区(其父 .el-form-item__content 为 flex+align-items:flex-start,
+// 不设宽度会按内容收缩,导致审批流程卡片无法 100%)
+.flow-rule-field {
+  width: 100%;
+}
+
 .box-card {
-  width: 96%;
+  width: 100%;
   margin-bottom: 10px;
   box-shadow: unset !important;
 


### PR DESCRIPTION
## Summary
Fixes payloads/behaviour broken by the Element UI → Element Plus (Vue 3) migration, plus several form-control layout cleanups.

- **Chat AI settings**: revert the `CHAT_AI_PROVIDERS` rewrite back to the flat fields the backend expects (`CHAT_AI_TYPE` = `gpt`/`deep-seek`, `GPT_*`/`DEEPSEEK_*`/`CUSTOM_*` with per-type visibility + Test button). Fixes `"openai" 不是合法选项`.
- **Ticket flow rules** (`FlowRuleField`): declare `emits`/`inheritAttrs: false` so native radio input events don't bubble to the root and pollute the form value (which produced `rules: "i"`). Flow now submits `[{users:{...}}]`.
- **Edit-recipients transfer panel** (`Krry/paging/box`): restore panel border/header/search styling for Element Plus and stop the search box overflowing the panel.
- **GatewayTestDialog**: local port state (parents bind `:port` one-way, input was uneditable) + layout.
- **MarkdownEditor**: full width so it no longer collapses.
- **Announcement**: info alert type.
- Alignment/width fixes for MsgTemplate, FlowRuleField and other form fields.

## Tested
- `yarn lint` passes
- `yarn build:prod` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)