### PR TITLE
fix: quick-filter highlight in deep black theme and gateway zone prop

### DIFF
--- a/src/components/Table/DrawerListTable/index.vue
+++ b/src/components/Table/DrawerListTable/index.vue
@@ -12,7 +12,7 @@
       :action="action"
       :class="[action]"
       :component="drawerComponent"
-      :props="drawerProps"
+      :component-props="drawerProps"
       :title="drawerTitle"
       class="page-drawer"
     />

--- a/src/components/Table/ListTable/TableAction/QuickFilter.vue
+++ b/src/components/Table/ListTable/TableAction/QuickFilter.vue
@@ -280,8 +280,14 @@ export default {
           margin-left: -3px;
         }
 
+        // 高亮不只靠颜色:Deep black 等主题下 --color-primary 接近正文色,单纯变色看不出;
+        // 叠加加粗 + 下划线,任何主题下选中态都清晰可辨
         &.active {
           color: var(--color-primary);
+          font-weight: 600;
+          text-decoration: underline;
+          text-decoration-thickness: 2px;
+          text-underline-offset: 3px;
 
           i {
             visibility: visible;

--- a/src/views/assets/Zone/ZoneDetail/GatewayCreateUpdate.vue
+++ b/src/views/assets/Zone/ZoneDetail/GatewayCreateUpdate.vue
@@ -10,14 +10,22 @@ export default {
   components: {
     BaseAssetCreateUpdate
   },
+  props: {
+    zone: {
+      type: Object,
+      default: () => ({})
+    }
+  },
   data() {
+    const getZoneId = () => this.zone.id || this.$route.query.zone
+
     return {
       url: '/api/v1/assets/gateways/',
       updateInitial: async (initial) => {
         const url = `/api/v1/assets/platforms/?name__startswith=Gateway`
         const platform = await this.$axios.get(url)
         initial.platform = parseInt(platform[0].id)
-        initial.zone = this.$route.query.zone
+        initial.zone = getZoneId()
         return initial
       },
       addFieldsMeta: {
@@ -40,7 +48,7 @@ export default {
       createSuccessNextRoute: {
         name: 'ZoneDetail',
         params: {
-          id: this.$route.query.zone
+          id: getZoneId()
         },
         query: {
           tab: 'GatewayList'
@@ -49,7 +57,7 @@ export default {
       updateSuccessNextRoute: {
         name: 'ZoneDetail',
         params: {
-          id: this.$route.query.zone
+          id: getZoneId()
         },
         query: {
           tab: 'GatewayList'

--- a/src/views/assets/Zone/ZoneDetail/GatewayList.vue
+++ b/src/views/assets/Zone/ZoneDetail/GatewayList.vue
@@ -4,6 +4,7 @@
       ref="ListTable"
       :create-drawer="createDrawer"
       :detail-drawer="detailDrawer"
+      :drawer-props="{ zone: object }"
       :header-actions="headerActions"
       :resource="$tc('Gateway')"
       :table-config="tableConfig"


### PR DESCRIPTION
## Summary
- **QuickFilter**: the active filter item now uses bold + underline on top of the primary color. Under themes such as **Deep black** the backend-provided `--color-primary` is close to the body text color, so a color-only highlight was invisible; the extra weight/underline keeps the selected state clear in every theme.
- **Gateway create/update**: resolve the zone id from a passed `zone` prop and fall back to `route.query.zone`, so the drawer-based create/update flow resolves the correct zone. `DrawerListTable` now forwards `component-props`, and `GatewayList` passes `{ zone: object }`.

## Test
- `yarn lint` passes (pre-commit oxlint/oxfmt ran on staged files)
- Manual: switch to Deep black theme and toggle quick-filter options on list pages (e.g. asset permissions / account list); create & update a gateway from the Zone detail drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)