### PR TITLE
fix: ticket detail UI and form field refinements

### DIFF
--- a/src/components/Form/AutoDataForm/utils.js
+++ b/src/components/Form/AutoDataForm/utils.js
@@ -170,7 +170,8 @@ export class FormFieldGenerator {
   }
 
   setHelpText(field, remoteFieldMeta) {
-    let helpText = toSentenceCase(remoteFieldMeta['help_text'])
+    const remoteHelpText = remoteFieldMeta['help_text']
+    let helpText = typeof remoteHelpText === 'string' ? toSentenceCase(remoteHelpText) : ''
 
     if (!helpText) {
       return field

--- a/src/components/Form/DataForm/components/el-form-renderer/components/render-form-item.vue
+++ b/src/components/Form/DataForm/components/el-form-renderer/components/render-form-item.vue
@@ -83,17 +83,17 @@
         </el-radio>
       </template>
     </component>
-    <div v-if="data.helpText" :class="data.type" class="help-block">
+    <div v-if="helpText" :class="data.type" class="help-block">
       <el-alert
-        v-if="data.helpText.startsWith('!')"
+        v-if="helpText.startsWith('!')"
         :closable="false"
         class="help-warning"
         show-icon
         type="info"
       >
-        <span v-sanitize="data.helpText.replace(/^!/, '')" />
+        <span v-sanitize="helpText.replace(/^!/, '')" />
       </el-alert>
-      <span v-else v-sanitize="data.helpText" />
+      <span v-else v-sanitize="helpText" />
     </div>
     <div v-if="data.helpTextFormatter" class="help-block">
       <RenderHelpTextSafe :render-content="data.helpTextFormatter" />
@@ -175,6 +175,9 @@ export default {
     }
   },
   computed: {
+    helpText() {
+      return typeof this.data.helpText === 'string' ? this.data.helpText : ''
+    },
     itemProp() {
       return this.prop || this.data.id
     },

--- a/src/components/Form/FormFields/BasicTree.vue
+++ b/src/components/Form/FormFields/BasicTree.vue
@@ -3,7 +3,7 @@
     :data="iTree"
     :default-checked-keys="iValue"
     :default-expand-all="expandAll"
-    :default-expanded-keys="defaultExpanded"
+    :default-expanded-keys="iDefaultExpanded"
     :props="defaultProps"
     :render-content="renderContent"
     class="el-tree-custom"
@@ -71,11 +71,17 @@ export default {
       } else {
         return this.setTreeReadonly(this.tree)
       }
-    }
-  },
-  mounted() {
-    if (this.iTree && this.iTree.length > 0) {
-      this.defaultExpanded.push(this.iTree[0].value)
+    },
+    // 默认展开一层:根节点 value 与外部传入的 defaultExpanded 合并。
+    // el-tree 只在初始化时读取 default-expanded-keys,必须在首次渲染前就备好
+    // (原先在 mounted 里 push 太晚,且改动了 prop,故从不生效)
+    iDefaultExpanded() {
+      const keys = [...this.defaultExpanded]
+      const rootValue = this.iTree?.[0]?.value
+      if (rootValue !== undefined && !keys.includes(rootValue)) {
+        keys.push(rootValue)
+      }
+      return keys
     }
   },
   methods: {

--- a/src/components/Form/FormFields/CronTab/Crontab.vue
+++ b/src/components/Form/FormFields/CronTab/Crontab.vue
@@ -440,13 +440,6 @@ export default {
   }
 }
 
-.popup-result-scroll {
-  font-size: 12px;
-  line-height: 24px;
-  height: 10em;
-  overflow-y: auto;
-}
-
 :deep(.el-form-item) {
   &.el-form-item--small,
   &.el-form-item--small {

--- a/src/components/Form/FormFields/CronTab/components/Crontab-Result.vue
+++ b/src/components/Form/FormFields/CronTab/components/Crontab-Result.vue
@@ -67,8 +67,16 @@ export default {
 <style lang="scss" scoped>
 .popup-result-time {
   margin-top: 10px;
+  font-size: 12px;
 }
 .title {
   margin-bottom: 0;
+  font-size: 12px;
+}
+.popup-result-scroll {
+  height: 10em;
+  overflow-y: auto;
+  font-size: 12px;
+  line-height: 24px;
 }
 </style>

--- a/src/components/Form/FormFields/CronTab/index.vue
+++ b/src/components/Form/FormFields/CronTab/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="cron-tab-field">
     <div class="box">
-      <el-input v-model="input" clearable @clear="onClear" @focus="showDialog" />
+      <el-input v-model="input" clearable @clear="onClear" @click="showDialog" />
     </div>
     <Dialog
       v-model:visible="showCron"
@@ -49,7 +49,10 @@ export default {
       this.input = value
       this.$emit('change', value)
     },
-    showDialog() {
+    showDialog(event) {
+      if (event?.target?.closest('.el-input__clear')) {
+        return
+      }
       this.expression = this.input
       this.showCron = true
     },

--- a/src/views/tickets/RequestAssetPerm/Detail/TicketDetail.vue
+++ b/src/views/tickets/RequestAssetPerm/Detail/TicketDetail.vue
@@ -16,7 +16,7 @@
         :model="requestForm"
         class="assets"
         label-position="left"
-        label-width="140px"
+        label-width="auto"
       >
         <el-form-item :label="$tc('Node')">
           <Select2 v-bind="nodeSelect2" v-model="requestForm.nodes" style="width: 50% !important" />
@@ -287,6 +287,23 @@ export default {
 <style scoped>
 .assets {
   margin-top: 14px;
+}
+
+/* 开始/失效日期:与上方字段一致 50% 宽度;并修正时钟前缀图标
+   (全站 mixin 的 .el-input__icon{vertical-align:super} 会让图标偏上/错位) */
+.assets :deep(.el-date-editor.el-input) {
+  width: 50%;
+
+  .el-input__prefix,
+  .el-input__prefix-inner {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .el-input__icon {
+    vertical-align: middle;
+    height: auto;
+  }
 }
 
 .feed-activity-list .feed-element {

--- a/src/views/tickets/components/Comments.vue
+++ b/src/views/tickets/components/Comments.vue
@@ -280,6 +280,24 @@ export default {
   line-height: 1.5;
 }
 
+// 底部通过/拒绝/撤销/回复按钮统一到全站 30px 规范(原 size="small" 偏矮),图标与文字留 4px 间距
+:deep(.el-form-item .el-button) {
+  height: 30px;
+  min-height: 30px;
+  padding: 0 12px;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1;
+
+  .fa {
+    margin-right: 4px;
+  }
+
+  & + .el-button {
+    margin-left: 8px;
+  }
+}
+
 .feed-activity-list .feed-element {
   border-bottom: 1px solid #e7eaec;
 }

--- a/src/views/tickets/components/Details.vue
+++ b/src/views/tickets/components/Details.vue
@@ -86,4 +86,12 @@ export default {
 .item-text {
   display: inline-block;
 }
+
+// 长文本(如申请运行的命令 SQL)按需换行,不溢出卡片;
+// min-width:0 让 flex 子项可收缩,overflow-wrap:anywhere 允许在超长无空格串处断行
+.item-text {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 </style>


### PR DESCRIPTION
- BasicTree: expand the root node one level on init via a computed default-expanded-keys; the previous mounted() push ran after el-tree initialized (and mutated a prop), so it never took effect
- RequestAssetPerm ticket detail: center the datetime picker prefix icon and switch to label-width="auto" to remove the oversized label gap
- Comments: align the approve/reject/cancel/reply buttons to the 30px standard
- Details: let long field values (e.g. the requested SQL command) wrap inside the card instead of overflowing
- Form help text: guard against non-string help_text in AutoDataForm and render-form-item so it no longer breaks rendering
- CronTab: open the expression dialog on click instead of focus (ignoring the clear button) and tidy the result popup styles