### PR TITLE
fix: request upload-authorized username hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:prod": "vite build --mode production",
     "build:stage": "vite build --mode staging",
     "preview": "vite preview --host 0.0.0.0 --port 9526",
+    "test": "node --test tests/*.test.mjs",
     "lint": "oxlint src vite.config.js",
     "lint:fix": "oxlint --fix src vite.config.js",
     "fmt": "oxfmt --write src package.json vite.config.js .env.development .env.development.example .env.production .env.staging .oxlintrc.json .oxfmtrc.json",

--- a/src/views/ops/File/index.vue
+++ b/src/views/ops/File/index.vue
@@ -226,7 +226,8 @@ export default {
               .post('/api/v1/ops/username-hints/', {
                 nodes: nodes,
                 assets: hosts,
-                query: query
+                query: query,
+                action: 'upload'
               })
               .then((data) => {
                 const ns = data.map((item) => {

--- a/tests/file-transfer-username-hints.test.mjs
+++ b/tests/file-transfer-username-hints.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { parse } from '@vue/compiler-sfc'
+
+const projectRoot = fileURLToPath(new URL('..', import.meta.url))
+
+async function loadFileTransferOptions(store) {
+  const source = await readFile(`${projectRoot}/src/views/ops/File/index.vue`, 'utf8')
+  const { descriptor } = parse(source)
+  const script = descriptor.script.content
+    .replace(/^import .*$/gm, '')
+    .replace('export default', 'const component =')
+  const importNames = [
+    'Term',
+    'Page',
+    'IBox',
+    'createJob',
+    'getTaskDetail',
+    'JobUploadFile',
+    'formatFileSize',
+    'store',
+    'SelectJobAssetDialog',
+    'ConfirmRunAssetsDialog'
+  ]
+  const factory = new Function(...importNames, `${script}\nreturn component`)
+  return factory(...importNames.map((name) => (name === 'store' ? store : () => {})))
+}
+
+test('file transfer requests upload-authorized account hints', async () => {
+  const store = {
+    getters: {
+      currentOrgIsRoot: false,
+      publicSettings: { FILE_UPLOAD_SIZE_LIMIT_MB: 100 }
+    }
+  }
+  const component = await loadFileTransferOptions(store)
+  const requests = []
+  const context = {
+    $axios: {
+      post(url, data) {
+        requests.push({ url, data })
+        return Promise.resolve([])
+      }
+    },
+    $hasPerm: () => true,
+    $store: store,
+    $t: (value) => value,
+    $tc: (value) => value,
+    getSelectedNodesAndHosts: () => ({ hosts: ['asset-id'], nodes: [] })
+  }
+  const data = component.data.call(context)
+
+  data.runAsInput.el.query('', () => {})
+  await Promise.resolve()
+
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].url, '/api/v1/ops/username-hints/')
+  assert.equal(requests[0].data.action, 'upload')
+})


### PR DESCRIPTION
## What changed

- Send `action: upload` when the file transfer page requests account username hints.
- Add a focused regression test for the request payload and expose it through `yarn test`.

## Why

The username-hints endpoint is also used by quick jobs, where the required action is `connect`. The file transfer page must identify its operation so Core can return only accounts authorized for uploads and avoid suggesting accounts that execution will reject.

This follows the execution-time file transfer authorization introduced in #5586.

## Impact

The change is backward compatible with older Core versions, which ignore the additional request field. With the companion Core change, the autocomplete list is restricted to upload-authorized accounts.

## Validation

- `yarn test`: 1 test passed.
- `yarn lint`: passed.
- Targeted `oxfmt --check`: passed.
- `yarn build`: passed.

## Companion change

- jumpserver/jumpserver#17232
