### PR TITLE
fix(account): emit submit event for push parameters

### DIFF
--- a/src/views/assets/Platform/AutomationParamsSetting.vue
+++ b/src/views/assets/Platform/AutomationParamsSetting.vue
@@ -39,6 +39,7 @@ export default {
     Dialog,
     AutoDataForm
   },
+  emits: ['input', 'submit', 'update:visible', 'canSetting'],
   props: {
     value: {
       type: [String, Object],

--- a/src/views/assets/Platform/AutomationParamsSetting.vue
+++ b/src/views/assets/Platform/AutomationParamsSetting.vue
@@ -187,6 +187,7 @@ export default {
     },
     onSubmit(form) {
       this.$emit('input', form)
+      this.$emit('submit', form)
       this.isVisible = false
       this.$emit('update:visible', this.isVisible)
     },


### PR DESCRIPTION
## Problem

On **PAM → Accounts → Accounts**, submitting **Push Parameters** from an account's **Quick Actions → Push** closes the dialog without creating a push task.

## Cause

`AutomationParamsSetting.vue` did not emit the `submit` event expected by `AccountDetail/Detail.vue`, so the task-creation handler was never called.

## Fix

Forward the submitted form data to the parent handler while preserving the existing `input` update and dialog-close behavior.

## Verification

- `yarn lint`
- `yarn oxfmt --check src/views/assets/Platform/AutomationParamsSetting.vue`
- `yarn build:prod`