### PR TITLE
fix: always emit an array from AllOrSpec

### DIFF
--- a/src/components/Form/FormFields/AllOrSpec.vue
+++ b/src/components/Form/FormFields/AllOrSpec.vue
@@ -78,7 +78,8 @@ export default {
       }
     },
     emitValue() {
-      const payload = this.iValue
+      const value = this.iValue
+      const payload = Array.isArray(value) ? value : [value]
       this.$emit('input', payload)
       this.$emit('update:modelValue', payload)
     },


### PR DESCRIPTION
Selecting specific protocols then switching back to "all" emitted the string 'all', which the API rejects: Expected a list of items but got type "str". Wrap a non-array value before emitting.