### PR TITLE
fix: enable recent session connections

### DIFF
--- a/src/views/workbench/overview/components/Session.vue
+++ b/src/views/workbench/overview/components/Session.vue
@@ -75,7 +75,7 @@ export default {
                   name: 'connect',
                   icon: 'fa-desktop',
                   type: 'primary',
-                  can: ({ row }) => row.is_active,
+                  can: ({ row }) => Boolean(row.asset_id),
                   callback: ({ row }) => {
                     if (this.preference?.basic?.connect_default_open_method === 'new') {
                       openNewWindow(


### PR DESCRIPTION
## Summary
- Backport https://github.com/jumpserver/lina/pull/5694 to `v4`
- 工作台「最近会话」连接按钮使用 `can: ({ row }) => row.is_active`，但 `/api/v1/terminal/my-sessions/` 不返回 `is_active`
- 4.10.19 起 `ActionsFormatter` 改为 `disabled = !can` 后，`undefined` 会被当成不可点，导致按钮置灰

## Changes
- 移除 `src/views/workbench/overview/components/Session.vue` 中错误的 `is_active` 判断
- 该按钮语义是按资产/账号再次连接，不应依赖会话在线状态

## Test plan
- [x] 工作台 → 概览 → 最近会话，操作列连接图标可点击（非置灰）
- [x] 点击后正常打开 Luna，并带上对应资产/账号
- [x] 无权限或资产已删除时，连接失败表现与「我的资产」中连接一致