### PR TITLE
fix: forward canSelect in AssetSelect for asset permission picker

### DIFF
--- a/src/components/Apps/AssetSelect/index.vue
+++ b/src/components/Apps/AssetSelect/index.vue
@@ -32,6 +32,7 @@
       :base-url="baseUrl"
       :tree-setting="treeSetting"
       :tree-url-query="treeUrlQuery"
+      :can-select="canSelect"
       :value="selectedValue"
       @cancel="handleCancel"
       @confirm="handleConfirm"
@@ -103,6 +104,12 @@ export default {
     disabled: {
       type: [Boolean, Function],
       default: false
+    },
+    canSelect: {
+      type: Function,
+      default(row, index) {
+        return true
+      }
     }
   },
   emits: ['change', 'input', 'update:model-value', 'update:modelValue'],

--- a/src/views/workbench/overview/components/Session.vue
+++ b/src/views/workbench/overview/components/Session.vue
@@ -75,7 +75,7 @@ export default {
                   name: 'connect',
                   icon: 'fa-desktop',
                   type: 'primary',
-                  can: ({ row }) => row.is_active,
+                  can: ({ row }) => Boolean(row.asset_id),
                   callback: ({ row }) => {
                     if (this.preference?.basic?.connect_default_open_method === 'new') {
                       openNewWindow(


### PR DESCRIPTION
## Summary
- Fix asset permission "Add asset" dialog where already authorized assets remain selectable.
- Root cause: after AssetSelect refactor (since v4.10.17), `canSelect` from `AssetRelationCard` was dropped because `inheritAttrs: false` and the prop was not forwarded to `AssetSelectDialog`.
- Declare `canSelect` prop and pass `:can-select="canSelect"` to `AssetSelectDialog`, same pattern as `ResourceSelect`.

Fixes jumpserver/jumpserver#17438

## Changes
- `src/components/Apps/AssetSelect/index.vue`
  - add `canSelect` prop
  - forward it to `AssetSelectDialog`

## Test plan
- [ ] Open an existing asset permission that already has assets
- [ ] Click add assets in the permission detail page
- [ ] Already authorized assets are grayed out / not selectable
- [ ] Newly selected assets can still be added successfully
- [ ] Browser hard refresh after deploy to avoid stale UI cache

## 实际效果图如下（v4.10.19）：
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/1a524c86-06da-4e3d-b60e-7f1c0eafac1b" />
