### PR TITLE
fix: send null when clearing account su_from

### DIFF
--- a/src/components/Apps/AccountCreateUpdateForm/index.vue
+++ b/src/components/Apps/AccountCreateUpdateForm/index.vue
@@ -167,6 +167,11 @@ export default {
       if (!form.secret) {
         delete form['secret']
       }
+
+      if (form.su_from === '' || form.su_from === undefined) {
+        form.su_from = null
+      }
+
       if (this.account?.name) {
         if (this.account.payload && this.account.payload === 'pam_account_clone') {
           this.$emit('add', form)

--- a/src/views/accounts/Account/AccountDetail/Detail.vue
+++ b/src/views/accounts/Account/AccountDetail/Detail.vue
@@ -213,7 +213,7 @@ export default {
             change: (value) => {
               const relationUrl = `/api/v1/accounts/accounts/${this.object.id}/`
               return this.$axios.patch(relationUrl, {
-                su_from: value,
+                su_from: value || null,
                 name: this.object.name
               })
             }


### PR DESCRIPTION
## Summary
- When clearing「切换自」, submit `"su_from": null` instead of omitting the field.
- Related to jumpserver/jumpserver#17448

## Test plan
- [ ] Clear su_from on account update form and save
- [ ] Request payload contains `"su_from": null`
- [ ] Reopen account, su_from is empty